### PR TITLE
Handling KeyError "no buffer_queue_length key"

### DIFF
--- a/td_agent.py
+++ b/td_agent.py
@@ -100,7 +100,11 @@ class ConcreteJob(base.JobBase):
         response = self._get_monitor_agent_plugin(self.url)
 
         for entry in response['plugins']:
-            if entry['output_plugin'] is True:
+            if (
+                (entry['output_plugin'] is True)
+                and
+                ('buffer_queue_length' in entry.keys())
+            ):
                 plugin_name = self._generate_plugin_name(
                     plugin_id=entry['plugin_id'],
                     type=entry['type']
@@ -161,11 +165,16 @@ class ConcreteJob(base.JobBase):
                 # generate plugin config items
                 if 'config' in entry:
                     if 'buffer_queue_limit' in entry['config']:
-                        buffer_queue_limit = entry['config']['buffer_queue_limit']
+                        buffer_queue_limit = (
+                            entry['config']['buffer_queue_limit']
+                        )
 
                     else:
                         self.logger.info(
-                            '"buffer_queue_limit" doesn\'t exist in "config" section.'
+                            (
+                                '"buffer_queue_limit" doesn\'t exist '
+                                'in "config" section.'
+                            )
                         )
                         buffer_queue_limit = -1
 


### PR DESCRIPTION
- All `output_plugin`s don't support output buffer information to `monitor_agent`'s json.

e.g: copy type plugin.. etc

``` json
{
  "plugins": [
    {
      "config": {
        "type": "copy"
      },
      "output_plugin": true,
      "plugin_id": "object:3fbd2af24a64",
      "retry_count": null,
      "type": "copy"
    }
  ]
}
```
